### PR TITLE
Wrap TFB case study body in paragraph

### DIFF
--- a/src/pages/techforbetter.js
+++ b/src/pages/techforbetter.js
@@ -73,7 +73,7 @@ const LinkWrapper = styled.a.attrs({
 const CaseStudy = ({ title, url, children }) => (
   <div className="flex flex-column justify-between font-4 mb5-ns mb3">
     <_SubHeading className="mb1">{title}</_SubHeading>
-    {children}
+    <p>{children}</p>
     <_Link href={url} className="mt1" target="_blank" rel="noopener noreferrer">
       <img src={link_arrow_button} className="mr1" />
       Check it out!


### PR DESCRIPTION
Otherwise the links become flex children and get laid out wrongly

Fixes #363